### PR TITLE
NXP-21356 [WIP] Add Versionning pill and view

### DIFF
--- a/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/i18n/messages-fr.json
+++ b/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/i18n/messages-fr.json
@@ -1,5 +1,7 @@
 {
-  "app.document.snapshotCreated": "La dossier a été versionné.",
+  "app.document.snapshotCreated": "La dossier a été versionné. Cliquez sur l'onglet Versions pour parcourir la structure versionnée.",
+  "app.document.chooseVersion": "Sélectionnez une version du dossier :",
+  "browser.versioning": "Versions",
   "label.document.type.snapshotablefolder": "Dossier versionnable",
   "snapshotButton.tooltip": "Créer une version du dossier"
 }

--- a/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/i18n/messages.json
+++ b/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/i18n/messages.json
@@ -1,5 +1,7 @@
 {
-  "app.document.snapshotCreated": "The folder has been versioned.",
+  "app.document.snapshotCreated": "The folder has been versioned. Go to the Versioning pill to browse the snapshotted structure.",
+  "app.document.chooseVersion": "Choose a version of the folder:",
+  "browser.versioning": "Versioning",
   "label.document.type.snapshotablefolder": "Versionable Folder",
   "snapshotButton.tooltip": "Snapshot the folder"
 }

--- a/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/nuxeo-tree-snapshot/nuxeo-document-versioning-pill.html
+++ b/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/nuxeo-tree-snapshot/nuxeo-document-versioning-pill.html
@@ -1,0 +1,54 @@
+<!--
+(C) Copyright 2017 Nuxeo SA (http://nuxeo.com/) and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contributors:
+  Estelle Giuly <egiuly@nuxeo.com>
+-->
+
+<!--
+`nuxeo-document-versioning-pill`
+@group Nuxeo UI
+@element nuxeo-document-versioning-pill
+-->
+<dom-module id="nuxeo-document-versioning-pill">
+  <template>
+    <style>
+      :host:focus {
+        outline: none;
+      }
+      paper-item {
+        --paper-item-focused-before: {
+          background: none;
+        };
+      }
+    </style>
+
+    <template is="dom-if" if="[[hasFacet(document, 'Snapshot')]]">
+      <paper-item name="versioning">[[i18n('browser.versioning')]]</paper-item>
+    </template>
+
+  </template>
+
+  <script>
+    Polymer({
+      is: 'nuxeo-document-versioning-pill',
+      behaviors: [Nuxeo.I18nBehavior, Nuxeo.FiltersBehavior],
+      properties: {
+        document: Object,
+      }
+    });
+  </script>
+
+</dom-module>

--- a/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/nuxeo-tree-snapshot/nuxeo-document-versioning-view.html
+++ b/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/nuxeo-tree-snapshot/nuxeo-document-versioning-view.html
@@ -1,0 +1,58 @@
+<!--
+(C) Copyright 2017 Nuxeo SA (http://nuxeo.com/) and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contributors:
+  Estelle Giuly <egiuly@nuxeo.com>
+-->
+
+<!--
+`nuxeo-document-versioning-view`
+@group Nuxeo UI
+@element nuxeo-document-versioning-view
+-->
+<dom-module id="nuxeo-document-versioning-view">
+  <template>
+    <style>
+      .title {
+        display: inline-block;
+      }
+
+      nuxeo-document-versions {
+        margin: 0 5px;
+      }
+    </style>
+
+    <!-- Version choice -->
+    <paper-card>
+      <h3 class="title">[[i18n('app.document.chooseVersion')]]</h3>
+
+      <template is="dom-if" if="[[hasFacet(document, 'Versionable')]]">
+        <nuxeo-document-versions document="[[document]]"></nuxeo-document-versions>
+      </template>
+    </paper-card>
+
+  </template>
+
+  <script>
+    Polymer({
+      is: 'nuxeo-document-versioning-view',
+      behaviors: [Nuxeo.I18nBehavior, Nuxeo.FiltersBehavior],
+      properties: {
+        document: Object,
+      }
+    });
+  </script>
+
+</dom-module>

--- a/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/nuxeo-tree-snapshot/nuxeo-tree-snapshot.html
+++ b/nuxeo-tree-snapshot-web-ui/src/main/resources/web/nuxeo.war/ui/nuxeo-tree-snapshot/nuxeo-tree-snapshot.html
@@ -1,7 +1,26 @@
+<!-- DOCUMENT_ACTIONS -->
 <link rel="import" href="nuxeo-snapshot-folder-button.html">
 
 <nuxeo-slot-content name="snapshotFolderButton" slot="DOCUMENT_ACTIONS">
   <template>
     <nuxeo-snapshot-folder-button document="[[document]]"></nuxeo-snapshot-folder-button>
+  </template>
+</nuxeo-slot-content>
+
+<!-- DOCUMENT_VIEWS_ITEMS -->
+<link rel="import" href="nuxeo-document-versioning-pill.html">
+
+<nuxeo-slot-content name="snapshottedFolderPill" slot="DOCUMENT_VIEWS_ITEMS">
+  <template>
+    <nuxeo-document-versioning-pill name="versioning" document="[[document]]"></nuxeo-document-versioning-pill>
+  </template>
+</nuxeo-slot-content>
+
+<!-- DOCUMENT_VIEWS_PAGES -->
+<link rel="import" href="nuxeo-document-versioning-view.html">
+
+<nuxeo-slot-content name="snapshottedFolderView" slot="DOCUMENT_VIEWS_PAGES">
+  <template>
+    <nuxeo-document-versioning-view name="versioning" document="[[document]]"></nuxeo-document-versioning-view>
   </template>
 </nuxeo-slot-content>


### PR DESCRIPTION
WORK IN PROGRESS, do not merge

https://jira.nuxeo.com/browse/NXP-21356

3rd subtask: https://jira.nuxeo.com/browse/NXP-21442

<img width="1277" alt="capture d ecran 2017-01-13 a 16 09 26" src="https://cloud.githubusercontent.com/assets/21174666/21934738/ddd0edd8-d9aa-11e6-8e59-ef665f9c563b.png">

To Do:
- fix the `iron-selected` class which currently applies to `nuxeo-document-versionning-pill` instead of `paper-item name="versionning"`
- in `nuxeo-web-ui`/`nuxeo-document-versions.html` fire an event when selecting a version instead of calling `_showVersion`
(https://github.com/nuxeo/nuxeo-web-ui/blob/master/elements/nuxeo-document-versions/nuxeo-document-versions.html#L139)
- listen to this event and display the snapshotted tree
- put the Versioning pill between the Permission and History pills

