### PR TITLE
Made compatible with nuxeo 9.10 (ecm.isTrashed not supported)

### DIFF
--- a/nuxeo-tree-snapshot-core/pom.xml
+++ b/nuxeo-tree-snapshot-core/pom.xml
@@ -44,6 +44,11 @@
       <groupId>org.nuxeo.ecm.automation</groupId>
       <artifactId>nuxeo-automation-server</artifactId>
     </dependency>
+  <dependency>
+      <groupId>org.nuxeo.ecm.platform</groupId>
+      <artifactId>nuxeo-platform-rendition-publisher</artifactId>
+  </dependency>
+
     <!-- Publishing test -->
     <dependency>
       <groupId>org.nuxeo.ecm.platform</groupId>

--- a/nuxeo-tree-snapshot-core/src/main/java/org/nuxeo/snapshot/SnapshotableAdapter.java
+++ b/nuxeo-tree-snapshot-core/src/main/java/org/nuxeo/snapshot/SnapshotableAdapter.java
@@ -145,7 +145,7 @@ public class SnapshotableAdapter implements Snapshot, Serializable {
 
         doc.getCoreSession().save();
         String query = "SELECT ecm:uuid FROM Document WHERE ecm:parentId = '" + doc.getId()
-                + "' AND ecm:isTrashed = 0 ORDER BY ecm:pos";
+                + "' AND ecm:currentLifeCycleState <> 'deleted' ORDER BY ecm:pos";
         try (IterableQueryResult res = doc.getCoreSession().queryAndFetch(query, "NXQL")) {
 
             vuuids = new String[(int) res.size()];

--- a/nuxeo-tree-snapshot-core/src/main/java/org/nuxeo/snapshot/pub/FolderishProxyFactory.java
+++ b/nuxeo-tree-snapshot-core/src/main/java/org/nuxeo/snapshot/pub/FolderishProxyFactory.java
@@ -28,10 +28,11 @@ import org.nuxeo.ecm.platform.publisher.api.PublicationNode;
 import org.nuxeo.ecm.platform.publisher.api.PublishedDocument;
 import org.nuxeo.ecm.platform.publisher.impl.core.SimpleCorePublishedDocument;
 import org.nuxeo.ecm.platform.publisher.task.CoreProxyWithWorkflowFactory;
+import org.nuxeo.ecm.platform.rendition.publisher.RenditionPublicationFactory;
 import org.nuxeo.snapshot.Snapshot;
 import org.nuxeo.snapshot.Snapshotable;
 
-public class FolderishProxyFactory extends CoreProxyWithWorkflowFactory {
+public class FolderishProxyFactory extends RenditionPublicationFactory {
 
     protected DocumentModel subPublish(CoreSession session, DocumentModel parentProxy, Snapshot tree, boolean skipParent)
             {


### PR DESCRIPTION
Made the proxy factory inherit RenditionPublicationFactory to enable renditions